### PR TITLE
Add Gutenberg compatibility

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -209,3 +209,8 @@ require get_template_directory() . '/inc/customizer.php';
  * Load Jetpack compatibility file.
  */
 require get_template_directory() . '/inc/jetpack.php';
+
+/**
+ * Load Gutenberg compatibility file.
+ */
+require get_template_directory() . '/inc/gutenberg.php';

--- a/src/inc/extras.php
+++ b/src/inc/extras.php
@@ -45,6 +45,10 @@ function adirondack_body_classes( $classes ) {
 		}
 	}
 
+	if ( is_singular() && false !== strpos( get_queried_object()->post_content, '<!-- wp:' ) ) {
+		$classes[] = 'is-gutenberg';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'adirondack_body_classes' );

--- a/src/inc/gutenberg.php
+++ b/src/inc/gutenberg.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Gutenberg Compatibility File
+ *
+ * @package Adirondack
+ */
+
+function adirondack_add_gutenberg_support() {
+	add_theme_support( 'gutenberg', array(
+		'wide-images' => true,
+		'colors' => array(
+			'#1C2026',
+			'#2A3644',
+			'#5d6876',
+			'#A5BCD4',
+			'#D7E5F3',
+		),
+	) );
+}
+add_action( 'after_setup_theme', 'adirondack_add_gutenberg_support' );

--- a/src/sass/site/_site.scss
+++ b/src/sass/site/_site.scss
@@ -5,6 +5,7 @@
 @import "primary/index";
 @import "primary/archives";
 @import "primary/single-post";
+@import "primary/gutenberg";
 
 .singular {
 	@import "layout/content-sidebar";
@@ -15,7 +16,8 @@
 	@import "layout/full-width";
 }
 
-.search, .error404 {
+.search,
+.error404 {
 	@import "primary/search";
 }
 
@@ -25,7 +27,8 @@
 10.2 Post Formats
 --------------------------------------------------------------*/
 .single-format-image,
-.single-format-video {
+.single-format-video,
+.single.is-gutenberg {
 	@import "layout/full-width";
 }
 

--- a/src/sass/site/layout/_full-width.scss
+++ b/src/sass/site/layout/_full-width.scss
@@ -7,7 +7,7 @@
 .hentry {
 	margin: 0 60px 100px 120px;
 	max-width: $size__site-main;
-	overflow: hidden;
+	overflow: visible;
 }
 
 .entry-content {

--- a/src/sass/site/primary/_gutenberg.scss
+++ b/src/sass/site/primary/_gutenberg.scss
@@ -1,0 +1,73 @@
+// Alignment
+
+.aligncenter {
+	text-align: center;
+}
+
+// Image support
+.alignwide {
+	width: calc( 100vw - 320px );
+	margin-bottom: 1em;
+
+	@media (max-width: 1190px) {
+		width: calc( 100vw - 140px );
+		margin-left: -60px;
+	}
+
+	@media (max-width: 800px) {
+		width: calc( 100vw - 120px );
+		margin-left: -20px;
+	}
+
+	@media (max-width: 450px) {
+		width: calc( 100vw - 60px );
+		margin-left: -20px;
+	}
+}
+
+.wp-block-cover-image,
+.alignfull {
+	width: calc( 100vw - 60px );
+	margin-left: -120px;
+	margin-bottom: 1em;
+
+	@media (max-width: 800px) {
+		margin-left: -60px;
+	}
+
+	@media (max-width: 450px) {
+		margin-left: -20px;
+	}
+}
+
+// Specificity for the cover image header color
+.wp-block-cover-image.wp-block-cover-image h2 {
+	color: white;
+}
+
+// @todo Button needs a hover state
+.wp-block-button {
+	a:link,
+	a:visited {
+		color: white;
+	}
+
+	a:hover,
+	a:active,
+	a:focus {
+		color: white;
+	}
+
+	a:focus {
+		text-decoration: underline;
+	}
+}
+
+// Remove max-width off the cover text.
+.wp-block-cover-text {
+	margin-bottom: 1.5em;
+
+	p {
+		max-width: 100%;
+	}
+}


### PR DESCRIPTION
Adds support for Gutenberg features in Adirondack. This PR:

- Forces all gutenberg-created posts to a single-column layout
- Styles the full-width and wide-width content
- Adds our custom theme colors to the available color palette
- Updates style of cover text, fixing width/alignment
- Styles button, which has no good hover state or contrast detection